### PR TITLE
Add ability to AJAX submit CartForm

### DIFF
--- a/_config/extensions.yml
+++ b/_config/extensions.yml
@@ -14,3 +14,11 @@ AddProductForm:
     - ShoppingCartAjax
     - AjaxControllerExtension
     - ViewableCart
+CartForm:
+  extensions:
+    - ShoppingCartAjax
+    - AjaxControllerExtension
+    - ViewableCart
+CartPage_Controller:
+  extensions:
+    - ShoppingCartAjax


### PR DESCRIPTION
This allows the extension of the CartForm to work with AJAX submission. The only issue is it will not work come version 2.0 due to https://github.com/burnbright/silverstripe-shop/commit/e04eb1f5498d90630b7282b11d2e68507341ea1a How did you want to proceed. I will fix and then squash all commits to together.
