### PR TITLE
Improvements for AJAX enabled CartForm.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Install via composer:
 composer require markguinn/silverstripe-shop-ajax:dev-master
 ```
 
+Please make sure you completely install `markguinn/silverstripe-ajax` by also including needed CSS and JS files. 
+A minimal working setup requires `base.js` from `markguinn/silverstripe-ajax`. 
+
 
 Developer(s)
 ------------

--- a/code/ShoppingCartAjax.php
+++ b/code/ShoppingCartAjax.php
@@ -27,7 +27,7 @@ class ShoppingCartAjax extends Extension {
 				'quantity'  => $quantity,
 			));
 
-			if(self::config()->show_ajax_messages) {
+			if(self::config()->show_ajax_messages && $this->owner->cart) {
 				$response->triggerEvent('statusmessage', array(
 					'content'   => $this->owner->cart->getMessage(),
 					'type'      => $this->owner->cart->getMessageType(),
@@ -63,7 +63,7 @@ class ShoppingCartAjax extends Extension {
 				'quantity'  => $quantity,
 			));
 
-			if(self::config()->show_ajax_messages) {
+			if(self::config()->show_ajax_messages && $this->owner->cart) {
 				$response->triggerEvent('statusmessage', array(
 					'content'   => $this->owner->cart->getMessage(),
 					'type'      => $this->owner->cart->getMessageType(),
@@ -104,7 +104,7 @@ class ShoppingCartAjax extends Extension {
 				'quantity'  => 0,
 			));
 
-			if(self::config()->show_ajax_messages) {
+			if(self::config()->show_ajax_messages && $this->owner->cart) {
 				$response->triggerEvent('statusmessage', array(
 					'content'   => $this->owner->cart->getMessage(),
 					'type'      => $this->owner->cart->getMessageType(),
@@ -146,7 +146,7 @@ class ShoppingCartAjax extends Extension {
 				'quantity'  => $quantity,
 			));
 
-			if(self::config()->show_ajax_messages) {
+			if(self::config()->show_ajax_messages && $this->owner->cart) {
 				$response->triggerEvent('statusmessage', array(
 					'content'   => $this->owner->cart->getMessage(),
 					'type'      => $this->owner->cart->getMessageType(),
@@ -184,7 +184,7 @@ class ShoppingCartAjax extends Extension {
 				'action'    => 'clear',
 			));
 
-			if(self::config()->show_ajax_messages) {
+			if(self::config()->show_ajax_messages && $this->owner->cart) {
 				$response->triggerEvent('statusmessage', array(
 					'content'   => $this->owner->cart->getMessage(),
 					'type'      => $this->owner->cart->getMessageType(),
@@ -276,7 +276,7 @@ class ShoppingCartAjax extends Extension {
 				'quantity'  => $quantity,
 			));
 
-			if(self::config()->show_ajax_messages) {
+			if(self::config()->show_ajax_messages && $this->owner->cart) {
 				$response->triggerEvent('statusmessage', array(
 					'content'   => $this->owner->cart->getMessage(),
 					'type'      => $this->owner->cart->getMessageType(),
@@ -299,6 +299,7 @@ class ShoppingCartAjax extends Extension {
 	 */
 	public function updateCartForm(&$form, $cart) {
 		$form->addExtraClass('ajax');
+		$form->setAttribute('data-ajax-region','CartFormAjax');
 	}
 
 
@@ -311,9 +312,6 @@ class ShoppingCartAjax extends Extension {
 		if ($request->isAjax()) {
 			if (!$response) $response = $this->owner->getAjaxResponse();
 			$this->setupRenderContexts($response);
-
-			$data['Editable'] = true;
-			$response->pushRegion('CartTable', $this->owner->cart, $data);
 
 			if(self::config()->show_ajax_messages) {
 				$response->triggerEvent('statusmessage', array(
@@ -329,6 +327,9 @@ class ShoppingCartAjax extends Extension {
 			// requests the redirect eliminates the need for this but under
 			// ajax the total lags behind the subtotal without this.
 			ShoppingCart::curr()->calculate();
+
+			$response->pushRegion('CartFormAjax', $this->owner, array('Editable' => true));
+
 		}
 	}
 

--- a/templates/CartFormAjax.ss
+++ b/templates/CartFormAjax.ss
@@ -1,0 +1,1 @@
+$forTemplate


### PR DESCRIPTION
Added a note to the readme about adding `base.js`. A required installation step a lot of people will miss if not explicitly noted.

Updated CartForm response handling and added a separate template to enable AJAX for the shopping cart.
Added checks to ensure a cart exists before accessing methods of it. This fixes an issue where an empty cart would trigger an error when adding a product via AJAX.
