### PR TITLE
Replaced "burnbright/silverstripe-shop" dependency with "silvershop/core"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 	},
 	"require": {
 		"silverstripe/framework": "~3.1",
-    "silvershop/core": "~1.0",
+    "silvershop/core": "~1.0 || ~2.0",
 		"markguinn/silverstripe-ajax": "~1.0.0"
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 	},
 	"require": {
 		"silverstripe/framework": "~3.1",
-		"burnbright/silverstripe-shop": "~1.0",
+    "silvershop/core": "~1.0",
 		"markguinn/silverstripe-ajax": "~1.0.0"
 	}
 }


### PR DESCRIPTION
This is required to keep from having two instances of the SilverShop add-on.
