### PR TITLE
Check if cart is actually an instance of `ShoppingCart`.

### DIFF
--- a/code/ShoppingCartAjax.php
+++ b/code/ShoppingCartAjax.php
@@ -365,7 +365,7 @@ class ShoppingCartAjax extends Extension
 
         $message = '';
         $type = '';
-        if ($this->owner->cart) {
+        if ($this->owner->cart && $this->owner->cart instanceof ShoppingCart) {
             $message = $this->owner->cart->getMessage();
             $type = $this->owner->cart->getMessageType();
             $this->owner->cart->clearMessage();


### PR DESCRIPTION
Seems to be of type `Order` where the `ViewableCart` extension comes into play and thus raises an error.
